### PR TITLE
fix: Resolve version before checking arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,17 @@ To install the previous minor release of Go:
 gimme oldstable
 ```
 
-To install the most recent patch of the release specified in the `go.mod` file:
+To install the release specified in the `go.mod` file:
 
 ``` bash
 gimme module
 ```
+
+If the `go` directive in the go.mod is in the form `go 1.21`,
+`gimme module` will install the latest patch version, e.g. `1.21.5`.
+However, if the `go` directive in go.mod is in the form `go 1.21.3`,
+`gimme module` will install the exact version, `1.21.3`.
+Note that the latter form is supported only by Go 1.21 or later.
 
 Or to install and use the development version (master branch) of Go:
 

--- a/gimme
+++ b/gimme
@@ -916,9 +916,14 @@ case "${GIMME_ARCH}" in
 x86_64) GIMME_ARCH=amd64 ;;
 x86) GIMME_ARCH=386 ;;
 arm64)
-	if [[ "${GIMME_GO_VERSION}" != master && "$(_versint "${GIMME_GO_VERSION}")" < "$(_versint 1.5)" ]]; then
+	min_arm64_version=1.5
+	if [[ "${GIMME_HOSTOS}" == 'darwin' ]]; then
+		min_arm64_version=1.16
+	fi
+
+	if [[ "${GIMME_GO_VERSION}" != master && "$(_versint "${GIMME_GO_VERSION}")" < "$(_versint "$min_arm64_version")" ]]; then
 		echo >&2 "error: ${GIMME_ARCH} is not supported by this go version"
-		echo >&2 "try go1.5 or newer"
+		echo >&2 "try go${min_arm64_version} or newer"
 		exit 1
 	fi
 	if [[ "${GIMME_HOSTOS}" == "linux" && "${GIMME_HOSTARCH}" != "${GIMME_ARCH}" ]]; then

--- a/gimme
+++ b/gimme
@@ -904,6 +904,14 @@ if [[ -n "${2}" ]]; then
 	GIMME_VERSION_PREFIX="${2}"
 fi
 
+case "${GIMME_GO_VERSION}" in
+stable) GIMME_GO_VERSION=$(_get_curr_stable) ;;
+oldstable) GIMME_GO_VERSION=$(_get_old_stable) ;;
+module) GIMME_GO_VERSION=$(_resolve_version module) ;;
+esac
+
+_assert_version_given "$@"
+
 case "${GIMME_ARCH}" in
 x86_64) GIMME_ARCH=amd64 ;;
 x86) GIMME_ARCH=386 ;;
@@ -926,14 +934,6 @@ x86) GIMME_HOSTARCH=386 ;;
 arm64) ;;
 arm*) GIMME_HOSTARCH=arm ;;
 esac
-
-case "${GIMME_GO_VERSION}" in
-stable) GIMME_GO_VERSION=$(_get_curr_stable) ;;
-oldstable) GIMME_GO_VERSION=$(_get_old_stable) ;;
-module) GIMME_GO_VERSION=$(_resolve_version module) ;;
-esac
-
-_assert_version_given "$@"
 
 ((force_install)) && _wipe_version "${GIMME_GO_VERSION}"
 


### PR DESCRIPTION
Fixes a bug where `gimme module` reports the following error
on macOS with ARM64.

    error: arm64 is not supported by this go version
    try go1.5 or newer

This occurs because the check for architecture
is performed before the `module` version
turns into a real version number with `_resolve_version`.

Fix by resolving version number before checking the architecture.
