### PR TITLE
fix(module): Handle X.Y.Z version format

### DIFF
--- a/gimme
+++ b/gimme
@@ -701,7 +701,15 @@ _get_module() {
 		die 'not a module'
 	fi
 	local version
-	version="$(awk '$1 == "go" { print $2 ".x"; exit }' "${GIMME_MODULE_PREFIX}go.mod")"
+	version="$(awk '$1 == "go" {
+		# Add ".x" suffix if only one ".".
+		if ($2 ~ /^[0-9]+\.[0-9]+$/) {
+			print $2 ".x";
+		} else {
+			print $2;
+		}
+		exit;
+	}' "${GIMME_MODULE_PREFIX}go.mod")"
 	if [ -z "$version" ]; then
 		die 'module has no go directive'
 	fi


### PR DESCRIPTION
Starting Go 1.21, the 'go' directive in go.mod files
takes the form:

    go X.Y.Z

(https://go.dev/doc/go1.21)

Given a go.mod file with such a directive,
`gimme module` fails because it turns "1.21.5" into "1.21.5.x".

This commit fixes the issue by adding the ".x" suffix
only if the version is in the form "X.Y".

As an added bonus, this will also work for pre-releases:

    go 1.22rc2
